### PR TITLE
add missing option logdefault, test kitchen

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source "http://rubygems.org"
+gem "test-kitchen", "< 1.0"

--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ Contributing
 - 2. Write you change
 - 3. Submit a Pull Request using Github
 
+Testing
+-------
+
+Test that the default recipe converges automatically with
+[test-kitchen](http://rubygems.org/gems/test-kitchen).
+
+    bundle install
+    bundle exec kitchen test
+
 License and Authors
 -------------------
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,6 +33,7 @@ default['kismet']['usbauto'] = "true"
 # Additional comments for specific settings are from the kismet.conf
 # file and credit goes to the Kismet project for their content.
 default['kismet']['config']['version']      = "2009-newcore"
+default['kismet']['config']['logdefault']   = "Kismet"
 default['kismet']['config']['servername']   = "my_server"
 default['kismet']['config']['logprefix']    = "/var/log/kismet"
 default['kismet']['config']['hidedata']     = "true"


### PR DESCRIPTION
Adds:
- logdefault option
- test kitchen via Gemfile

```
*** KISMET HAS ENCOUNTERED A FATAL ERROR AND CANNOT CONTINUE.  ***
Shutting down log files...
INFO: Shutting down plugins...
FATAL: No 'logdefault' specified on the command line or config file
```
